### PR TITLE
Fixes logic for making poison

### DIFF
--- a/zone/tradeskills.cpp
+++ b/zone/tradeskills.cpp
@@ -459,8 +459,8 @@ void Object::HandleCombine(Client* user, const NewCombine_Struct* in_combine, Ob
 		}
 	}
 	else if (spec.tradeskill == EQ::skills::SkillMakePoison) {
-		if (user_pp.class_ != ROGUE || user_pp.class_ != ENCHANTER) {
-			user->Message(Chat::Red, "Only rogues can mix poisons.");
+		if (user_pp.class_ != ROGUE && user_pp.class_ != ENCHANTER) {
+			user->Message(Chat::Red, "Only enchanters can mix poisons.");
 			auto outapp = new EQApplicationPacket(OP_TradeSkillCombine, 0);
 			user->QueuePacket(outapp);
 			safe_delete(outapp);


### PR DESCRIPTION
I think the way it was written, Enchanters also couldn't make poison (Enchanter != Rogue)