### PR TITLE
Adds logic for debuff clearing while resting

### DIFF
--- a/zone/client.h
+++ b/zone/client.h
@@ -1735,6 +1735,7 @@ private:
 	void DoManaRegen();
 	void DoStaminaHungerUpdate();
 	void CalcRestState();
+	void ClearRestingDetrimentalEffects();
 	// if they have aggro (AggroCount != 0) their timer is saved in m_pp.RestTimer, else we need to get current timer
 	inline uint32 GetRestTimer() const { return AggroCount ? m_pp.RestTimer : rest_timer.GetRemainingTime() / 1000; }
 	void UpdateRestTimer(uint32 new_timer);

--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -1973,7 +1973,7 @@ void Client::CalcRestState()
 				} else {
 					// Pyrelight custom code
 					// We clear all rest enabled debuffs if we're otherwise eligible for rest.
-					BuffFadeBySlot(j)
+					BuffFadeBySlot(j);
 				}
 		}
 	}

--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -1970,6 +1970,11 @@ void Client::CalcRestState()
 			if(IsDetrimentalSpell(buffs[j].spellid) && (buffs[j].ticsremaining > 0))
 				if(!DetrimentalSpellAllowsRest(buffs[j].spellid))
 					return;
+				else {
+					// Pyrelight custom code
+					// We clear all rest enabled debuffs if we're otherwise eligible for rest.
+					BuffFadeBySlot(j)
+				}
 		}
 	}
 

--- a/zone/client_process.cpp
+++ b/zone/client_process.cpp
@@ -1968,9 +1968,9 @@ void Client::CalcRestState()
 	for (unsigned int j = 0; j < buff_count; j++) {
 		if(IsValidSpell(buffs[j].spellid)) {
 			if(IsDetrimentalSpell(buffs[j].spellid) && (buffs[j].ticsremaining > 0))
-				if(!DetrimentalSpellAllowsRest(buffs[j].spellid))
+				if(!DetrimentalSpellAllowsRest(buffs[j].spellid)) {
 					return;
-				else {
+				} else {
 					// Pyrelight custom code
 					// We clear all rest enabled debuffs if we're otherwise eligible for rest.
 					BuffFadeBySlot(j)


### PR DESCRIPTION
This adds logic during the `CalcRestState` check which also will clear valid detrimental effects when the player is resting.

The check here is:
1) No aggro
2) Sitting / on horse
3) Rest timer (30 sec) elapsed
4) No other detrimental effects are flagged as blocking rest